### PR TITLE
export Parameters from the main blinx module

### DIFF
--- a/blinx/__init__.py
+++ b/blinx/__init__.py
@@ -1,8 +1,10 @@
+from .parameters import Parameters
 from .parameter_ranges import ParameterRanges  # noqa
 from .hyper_parameters import HyperParameters, create_step_sizes
 from .estimate import estimate_y, estimate_parameters
 
 __all__ = [
+    "Parameters",
     "ParameterRanges",
     "HyperParameters",
     "create_step_sizes",


### PR DESCRIPTION
blinx already exports `ParameterRanges` and `HyperParameters`, this maintains consistency with the other two "parameter" classes 